### PR TITLE
chore: add docker setup for all projects

### DIFF
--- a/setup/python-dotenv/Dockerfile
+++ b/setup/python-dotenv/Dockerfile
@@ -1,0 +1,13 @@
+FROM continuumio/miniconda3
+
+RUN apt-get update && apt-get install -y git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+RUN conda install python=3.11 -y
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+CMD ["bash"]

--- a/setup/tinydb/Dockerfile
+++ b/setup/tinydb/Dockerfile
@@ -1,0 +1,13 @@
+FROM continuumio/miniconda3
+
+RUN apt-get update && apt-get install -y git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+RUN conda install python=3.11 -y
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+CMD ["bash"]

--- a/setup/whoosh-reloaded/Dockerfile
+++ b/setup/whoosh-reloaded/Dockerfile
@@ -1,0 +1,13 @@
+FROM continuumio/miniconda3
+
+RUN apt-get update && apt-get install -y git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+RUN conda install python=3.11 -y
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+CMD ["bash"]


### PR DESCRIPTION
## What was done
Created Dockerfiles for all three projects in setup/<project>/Dockerfile.
Each project has its own isolated environment based on continuumio/miniconda3
with Python 3.11 and git installed, ensuring reproducibility across benchmarks.

## How to test
cd setup/python-dotenv
docker build -t eda-dotenv .
docker run --rm \
  -v $(pwd)/../../experiments/python-dotenv:/experiments \
  -v $(pwd)/../../results/python-dotenv:/results \
  eda-dotenv
  
  ## Notes
The CMD command is temporarily configured for bash.
It will be updated to the performance file when the experiments are ready.


Closes #2 