### PR TITLE
fix(whoosh): patch baseline to disable skip list for accurate comparison

### DIFF
--- a/experiments/whoosh-reloaded/baseline_whoosh-reloaded_skip-lists.py
+++ b/experiments/whoosh-reloaded/baseline_whoosh-reloaded_skip-lists.py
@@ -11,6 +11,9 @@ import time
 import whoosh.index as index
 from whoosh.fields import ID, TEXT, Schema
 from whoosh.query import And, Term
+from whoosh.matching.mcore import ListMatcher, SkipListMatcher
+
+SkipListMatcher.skip_to = ListMatcher.skip_to
 
 
 def parse_args():

--- a/results/whoosh-reloaded/result_whoosh-reloaded_skip-lists.json
+++ b/results/whoosh-reloaded/result_whoosh-reloaded_skip-lists.json
@@ -3,16 +3,16 @@
   "project": "whoosh-reloaded",
   "variant": "optimized",
   "baseline": {
-    "mean_ms": 9379.0924,
-    "std_ms": 1452.5428,
+    "mean_ms": 9057.8618,
+    "std_ms": 887.1988,
     "runs": 30
   },
   "optimized": {
-    "mean_ms": 8030.9395,
-    "std_ms": 898.9721,
+    "mean_ms": 8249.2731,
+    "std_ms": 341.5013,
     "runs": 30
   },
-  "improvement_pct": 14.37,
+  "improvement_pct": 8.93,
   "improvement_confirmed": false,
   "config": {
     "docs": 500000,


### PR DESCRIPTION
## What was done

- Patched the baseline script to monkey-patch `SkipListMatcher.skip_to` with `ListMatcher.skip_to` (linear scan), ensuring the baseline actually measures performance without the skip list optimization
- Re-ran the full experiment (500k docs, 100 query pairs, 30 runs) with accurate baseline vs optimized comparison
- Results: 8.93% improvement (9057ms baseline → 8249ms optimized), with a significant reduction in variance (std 887ms → 341ms)

## How to test

```bash
bash experiments/whoosh-reloaded/run_skip_lists.sh --docs 1000 --high-freq 200 --low-freq 20 --query-pairs 10 --runs 3
```

## Related issue

Closes #21